### PR TITLE
Fix the macOS build error in "Do not change directory when building".

### DIFF
--- a/src/static_julia.jl
+++ b/src/static_julia.jl
@@ -233,7 +233,7 @@ end
 function build_shared(s_file, o_file, verbose, optimize, debug, cc, cc_flags)
     command = `$cc -shared -o $s_file $o_file $(julia_flags(optimize, debug, cc_flags))`
     if isapple()
-        command = `$command -Wl,-install_name,@rpath/$s_file`
+        command = `$command -Wl,-install_name,@rpath/$(basename(s_file))`
     elseif iswindows()
         command = `$command -Wl,--export-all-symbols`
     end


### PR DESCRIPTION
Fixes the error currently in https://github.com/JuliaLang/PackageCompiler.jl/pull/70:
On macOS, the gcc flag `-install_name` must be set to `"@rpath/hello.dylib`, so
it must use `basename(s_name)`.